### PR TITLE
[Feature] 행사 신청 관련 Controller 구현

### DIFF
--- a/src/main/java/com/cu2mber/registrationservice/registration/controller/RegistrationController.java
+++ b/src/main/java/com/cu2mber/registrationservice/registration/controller/RegistrationController.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
-@RequestMapping("/registers")
+@RequestMapping("/registrations")
 public class RegistrationController {
 
     @PostMapping

--- a/src/main/java/com/cu2mber/registrationservice/registration/controller/RegistrationController.java
+++ b/src/main/java/com/cu2mber/registrationservice/registration/controller/RegistrationController.java
@@ -1,0 +1,83 @@
+package com.cu2mber.registrationservice.registration.controller;
+
+import com.cu2mber.registrationservice.registration.dto.command.RegistrationCreateCommand;
+import com.cu2mber.registrationservice.registration.dto.request.RegistrationCreateRequest;
+import com.cu2mber.registrationservice.registration.dto.response.RegistrationResponse;
+import com.cu2mber.registrationservice.registration.dto.response.RegistrationSummaryResponse;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RestController
+@RequestMapping("/registers")
+public class RegistrationController {
+
+    @PostMapping
+    public ResponseEntity<RegistrationResponse> createRegistration(@RequestBody @Valid RegistrationCreateRequest request) {
+
+        RegistrationCreateCommand command = new RegistrationCreateCommand(
+                1L,
+                request.recruitmentNo(),
+                request.participantCount(),
+                request.registrationDate()
+        );
+
+        RegistrationResponse response = new RegistrationResponse(
+                1L,
+                request.recruitmentNo(),
+                1L,
+                2,
+                request.registrationDate(),
+                LocalDateTime.now(),
+                null,
+                false,
+                false
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/{no}")
+    public ResponseEntity<RegistrationResponse> getRegistration(@PathVariable("no") Long no) {
+        RegistrationResponse response = new RegistrationResponse(
+                1L,
+                1L,
+                1L,
+                2,
+                LocalDate.of(2026, 3, 1),
+                LocalDateTime.now(),
+                null,
+                false,
+                false
+        );
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<RegistrationSummaryResponse>> getRegistrationPage(@PageableDefault(size = 10)Pageable pageable) {
+        RegistrationSummaryResponse response = new RegistrationSummaryResponse(
+                1L,
+                1L,
+                1L,
+                2,
+                LocalDate.of(2026, 3, 1),
+                LocalDateTime.now()
+        );
+
+        return ResponseEntity.ok(new PageImpl<>(List.of(response)));
+    }
+
+    @DeleteMapping("/{no}")
+    public ResponseEntity<Void> deleteRegistration(@PathVariable("no")Long no) {
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/java/com/cu2mber/registrationservice/registration/dto/command/RegistrationCreateCommand.java
+++ b/src/main/java/com/cu2mber/registrationservice/registration/dto/command/RegistrationCreateCommand.java
@@ -1,0 +1,15 @@
+package com.cu2mber.registrationservice.registration.dto.command;
+
+import java.time.LocalDate;
+
+public record RegistrationCreateCommand(
+
+        Long memberNo,
+
+        Long recruitmentNo,
+
+        Integer participantCount,
+
+        LocalDate registrationDate
+) {
+}

--- a/src/main/java/com/cu2mber/registrationservice/registration/dto/request/RegistrationCreateRequest.java
+++ b/src/main/java/com/cu2mber/registrationservice/registration/dto/request/RegistrationCreateRequest.java
@@ -1,0 +1,17 @@
+package com.cu2mber.registrationservice.registration.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDate;
+
+public record RegistrationCreateRequest(
+
+        Long recruitmentNo,
+
+        @JsonProperty("participant")
+        Integer participantCount,
+
+        @JsonProperty("date")
+        LocalDate registrationDate
+) {
+}

--- a/src/main/java/com/cu2mber/registrationservice/registration/dto/response/RegistrationResponse.java
+++ b/src/main/java/com/cu2mber/registrationservice/registration/dto/response/RegistrationResponse.java
@@ -1,0 +1,42 @@
+package com.cu2mber.registrationservice.registration.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@ToString
+@EqualsAndHashCode
+public class RegistrationResponse {
+
+    @JsonProperty("no")
+    Long registerNo;
+
+    Long recruitmentNo;
+
+    Long memberNo;
+
+//    @Setter
+//    @JsonProperty("recruit")
+//    Long recruitmentName;
+
+    @JsonProperty("participant")
+    Integer participantCount;
+
+    @JsonProperty("date")
+    LocalDate registrationDate;
+
+    @EqualsAndHashCode.Exclude
+    LocalDateTime createdAt;
+
+    @EqualsAndHashCode.Exclude
+    LocalDateTime deletedAt;
+
+    Boolean isCanceled;
+
+    Boolean isRefunded;
+}

--- a/src/main/java/com/cu2mber/registrationservice/registration/dto/response/RegistrationSummaryResponse.java
+++ b/src/main/java/com/cu2mber/registrationservice/registration/dto/response/RegistrationSummaryResponse.java
@@ -1,0 +1,35 @@
+package com.cu2mber.registrationservice.registration.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@ToString
+@EqualsAndHashCode
+public class RegistrationSummaryResponse {
+
+    @JsonProperty("no")
+    Long registerNo;
+
+    Long recruitmentNo;
+
+    Long memberNo;
+
+//    @Setter
+//    @JsonProperty("recruit")
+//    Long recruitmentName;
+
+    @JsonProperty("participant")
+    Integer participantCount;
+
+    @JsonProperty("date")
+    LocalDate registrationDate;
+
+    @EqualsAndHashCode.Exclude
+    LocalDateTime createdAt;
+}


### PR DESCRIPTION
## 📌 관련 이슈

- close #1 

## ✨ 변경 내용

- 행사 신청 기능을 위한 Controller 계층 생성
- 다음 API 엔드포인트 추가
  - **POST /registrations** : 신청 생성
  - **DELETE /registrations/{registrationId}** : 신청 취소
  - **GET /registrations/{registrationId}** : 신청 상세 조회
  - **GET /registrations** : 신청 목록 조회
- Request/Response DTO 정의

## ✅ 체크리스트

- [x] 빌드 및 테스트가 모두 통과했나요?
- [x] merge할 branch를 확인했나요? (예: `develop` → `main`)
- [x] Assignee를 지정했나요?
- [x] 코드 리뷰어를 지정했나요? (필요 시)

## 📝 기타 참고 사항

- 추후 비즈니스 로직 구현 예정
